### PR TITLE
Fix: TypeError, variable 'image' was already reassigned

### DIFF
--- a/grounded.py
+++ b/grounded.py
@@ -29,7 +29,6 @@ client = OpenAI()
 masks_isolated = []
 
 masks_to_xyxys = sv.mask_to_xyxy(masks=results.mask)
-image = cv2.imread(image)
 
 polygons = [sv.mask_to_polygons(mask) for mask in results.mask]
 


### PR DESCRIPTION
  File "/home/development/cv-book-svg/grounded.py", line 34, in <module>
    image = cv2.imread(image)
            ^^^^^^^^^^^^^^^^^
TypeError: Can't convert object to 'str' for 'filename'